### PR TITLE
Location visits can abut so we have to use open/closed intervals

### DIFF
--- a/src/sql/mrn_based_on_bed_and_datetime.sql
+++ b/src/sql/mrn_based_on_bed_and_datetime.sql
@@ -15,4 +15,5 @@ INNER JOIN {schema_name}.location loc
   ON lv.location_id = loc.location_id
 WHERE loc.location_string = %(location_string)s
   AND lv.admission_datetime <= %(observation_datetime)s
-  AND ( lv.discharge_datetime >= %(observation_datetime)s OR lv.discharge_datetime IS NULL )
+  -- location visits can abut, so can't use inclusive intervals at both ends
+  AND ( lv.discharge_datetime > %(observation_datetime)s OR lv.discharge_datetime IS NULL )


### PR DESCRIPTION
When running on synthetic data, I was getting two location visits for a measurement time if it fell exactly on the transfer time. It should be unambiguously in one or the other visit. This is unlikely to matter for real data.