### PR TITLE
Restart containers

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,6 +14,7 @@ services:
      - ../config/controller.env
     volumes:
       - ../waveform-export:/waveform-export
+    restart: unless-stopped
   waveform-exporter:
     build:
       context: ..
@@ -29,6 +30,7 @@ services:
       - ../config/exporter.env
     volumes:
       - ../waveform-export:/waveform-export
+    restart: unless-stopped
   waveform-hasher:
     build:
       context: ../PIXL
@@ -44,3 +46,4 @@ services:
       - "127.0.0.1:${HASHER_API_PORT}:8000"
     env_file:
       - ../config/hasher.env
+    restart: unless-stopped


### PR DESCRIPTION
Set a restart policy on all containers. This helps when, for example, rabbitmq/postgres are not yet up or go down temporarily, so it will keep trying after failure.