### PR TITLE
Pin docker image versions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.13-slim-bookworm AS waveform_base
+FROM python:3.13-slim-bookworm@sha256:8092ae2ef67061f9db412458dbdce44dbf16748fb3cae5cdbd020f467a9712d0 AS waveform_base
 LABEL authors="Stephen Thompson, Jeremy Stein"
 # Cron is really small. For the sake of not having to reinstall it all the time,
 # put it on both images even though we only need it on exporter.
@@ -6,7 +6,7 @@ RUN export DEBIAN_FRONTEND=noninteractive && \
     apt-get update && \
     apt-get install --yes --no-install-recommends cron && \
     apt-get autoremove --yes && apt-get clean --yes && rm -rf /var/lib/apt/lists/*
-COPY --from=ghcr.io/astral-sh/uv:latest /uv /uvx /bin/
+COPY --from=ghcr.io/astral-sh/uv@sha256:538e0b39736e7feae937a65983e49d2ab75e1559d35041f9878b7b7e51de91e4 /uv /uvx /bin/
 ARG UVCACHE=/root/.cache/uv
 COPY PIXL /PIXL
 WORKDIR /app


### PR DESCRIPTION
As well as the repeatability benefit, this allows docker builds to happen offline.