### PR TITLE
Implement opt out

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,8 @@ dependencies = [
 dev = [
     "pytest>=9.0.2",
     "stablehash==0.3.0",
+    "types-pika-ts",
+    "types-psycopg2",
 ]
 
 [project.scripts]

--- a/src/controller.py
+++ b/src/controller.py
@@ -10,16 +10,11 @@ import pika
 import db as db  # type:ignore
 import settings as settings  # type:ignore
 import csv_writer as writer  # type:ignore
-from utils import DedupeFilter
 
 logging.basicConfig(format="%(levelname)s:%(asctime)s: %(message)s")
 logger = logging.getLogger(__name__)
 logger.setLevel(settings.LOG_LEVEL)
 # logger.addFilter(DedupeFilter(window_seconds=60))
-
-emap_db = db.starDB()
-emap_db.init_query()
-emap_db.connect()
 
 
 class waveform_message:
@@ -45,66 +40,78 @@ def reject_message(ch, delivery_tag, requeue):
         logger.warning("Attempting to not acknowledge a message on a closed channel.")
 
 
-def waveform_callback(ch, method_frame, _header_frame, body):
-    logger.debug("Message received of length %s", len(body))
-    data = json.loads(body)
-    try:
-        location_string = data["mappedLocationString"]
-        observation_timestamp = data["observationTime"]
-        source_variable_id = data["sourceVariableId"]
-        source_channel_id = data["sourceChannelId"]
-        sampling_rate = data["samplingRate"]
-        units = data["unit"]
-        waveform_data = data["numericValues"]
-        mapped_location_string = data["mappedLocationString"]
-        logger.debug("Message is for loc %s, var %s, ch %s",
-                     location_string, source_variable_id, source_channel_id)
-    except IndexError as e:
-        reject_message(ch, method_frame.delivery_tag, False)
-        logger.error(
-            f"Waveform message {method_frame.delivery_tag} is missing required data {e}."
-        )
-        return
+class WaveformController:
+    def __init__(self):
+        self.emap_db = db.starDB()
+        self.emap_db.init_query()
+        self.emap_db.connect()
 
-    observation_time = datetime.fromtimestamp(observation_timestamp, tz=timezone.utc)
-    lookup_success = True
-    try:
-        matched_mrn = emap_db.get_row(location_string, observation_time)
-    except ValueError:
-        lookup_success = False
-        logger.error(
-            "Ambiguous or non existent match for location %s, obs time %s",
-            location_string,
-            observation_time,
-            exc_info=True,
-        )
-        matched_mrn = ("unmatched_mrn", "unmatched_nhs", "unmatched_csn", False)
-    except ConnectionError:
-        logger.error("Database error, will try again", exc_info=True)
-        reject_message(ch, method_frame.delivery_tag, True)
-        return
-
-    (mrn, nhs_no, csn, opt_out) = matched_mrn
-    if opt_out:
-        logger.info("Research opt-out is set for mrn %s, not writing.", mrn)
-        reject_message(ch, method_frame.delivery_tag, False)
-        return
-
-    if writer.write_frame(
-        waveform_data,
-        source_variable_id,
-        source_channel_id,
-        observation_timestamp,
-        units,
-        sampling_rate,
-        mapped_location_string,
-        csn,
-        mrn,
-    ):
-        if lookup_success:
-            ack_message(ch, method_frame.delivery_tag)
-        else:
+    def waveform_callback(self, ch, method_frame, _header_frame, body):
+        logger.debug("Message received of length %s", len(body))
+        data = json.loads(body)
+        try:
+            location_string = data["mappedLocationString"]
+            observation_timestamp = data["observationTime"]
+            source_variable_id = data["sourceVariableId"]
+            source_channel_id = data["sourceChannelId"]
+            sampling_rate = data["samplingRate"]
+            units = data["unit"]
+            waveform_data = data["numericValues"]
+            mapped_location_string = data["mappedLocationString"]
+            logger.debug(
+                "Message is for loc %s, var %s, ch %s",
+                location_string,
+                source_variable_id,
+                source_channel_id,
+            )
+        except IndexError as e:
             reject_message(ch, method_frame.delivery_tag, False)
+            logger.error(
+                f"Waveform message {method_frame.delivery_tag} is missing required data {e}."
+            )
+            return
+
+        observation_time = datetime.fromtimestamp(
+            observation_timestamp, tz=timezone.utc
+        )
+        lookup_success = True
+        try:
+            matched_mrn = self.emap_db.get_row(location_string, observation_time)
+        except ValueError:
+            lookup_success = False
+            logger.error(
+                "Ambiguous or non existent match for location %s, obs time %s",
+                location_string,
+                observation_time,
+                exc_info=True,
+            )
+            matched_mrn = ("unmatched_mrn", "unmatched_nhs", "unmatched_csn", False)
+        except ConnectionError:
+            logger.error("Database error, will try again", exc_info=True)
+            reject_message(ch, method_frame.delivery_tag, True)
+            return
+
+        (mrn, nhs_no, csn, opt_out) = matched_mrn
+        if opt_out:
+            logger.info("Research opt-out is set for mrn %s, not writing.", mrn)
+            reject_message(ch, method_frame.delivery_tag, False)
+            return
+
+        if writer.write_frame(
+            waveform_data,
+            source_variable_id,
+            source_channel_id,
+            observation_timestamp,
+            units,
+            sampling_rate,
+            mapped_location_string,
+            csn,
+            mrn,
+        ):
+            if lookup_success:
+                ack_message(ch, method_frame.delivery_tag)
+            else:
+                reject_message(ch, method_frame.delivery_tag, False)
 
 
 def receiver():
@@ -122,10 +129,11 @@ def receiver():
     channel = connection.channel()
     channel.basic_qos(prefetch_count=1)
 
+    controller = WaveformController()
     channel.basic_consume(
         queue=settings.RABBITMQ_QUEUE,
         auto_ack=False,
-        on_message_callback=waveform_callback,
+        on_message_callback=controller.waveform_callback,
     )
     logger.info("Connected to RabbitMQ, callback configured")
     try:
@@ -137,7 +145,6 @@ def receiver():
         logger.error("Received other exception")
         logger.error(e)
         raise e
-
 
     logger.info("Closing connection to RabbitMQ")
     connection.close()

--- a/src/controller.py
+++ b/src/controller.py
@@ -10,9 +10,12 @@ import pika
 import db as db  # type:ignore
 import settings as settings  # type:ignore
 import csv_writer as writer  # type:ignore
+from utils import DedupeFilter
 
 logging.basicConfig(format="%(levelname)s:%(asctime)s: %(message)s")
 logger = logging.getLogger(__name__)
+logger.setLevel(settings.LOG_LEVEL)
+# logger.addFilter(DedupeFilter(window_seconds=60))
 
 emap_db = db.starDB()
 emap_db.init_query()
@@ -43,6 +46,7 @@ def reject_message(ch, delivery_tag, requeue):
 
 
 def waveform_callback(ch, method_frame, _header_frame, body):
+    logger.debug("Message received of length %s", len(body))
     data = json.loads(body)
     try:
         location_string = data["mappedLocationString"]
@@ -53,6 +57,8 @@ def waveform_callback(ch, method_frame, _header_frame, body):
         units = data["unit"]
         waveform_data = data["numericValues"]
         mapped_location_string = data["mappedLocationString"]
+        logger.debug("Message is for loc %s, var %s, ch %s",
+                     location_string, source_variable_id, source_channel_id)
     except IndexError as e:
         reject_message(ch, method_frame.delivery_tag, False)
         logger.error(
@@ -72,10 +78,16 @@ def waveform_callback(ch, method_frame, _header_frame, body):
             observation_time,
             exc_info=True,
         )
-        matched_mrn = ("unmatched_mrn", "unmatched_nhs", "unmatched_csn")
+        matched_mrn = ("unmatched_mrn", "unmatched_nhs", "unmatched_csn", False)
     except ConnectionError:
         logger.error("Database error, will try again", exc_info=True)
         reject_message(ch, method_frame.delivery_tag, True)
+        return
+
+    (mrn, nhs_no, csn, opt_out) = matched_mrn
+    if opt_out:
+        logger.info("Research opt-out is set for mrn %s, not writing.", mrn)
+        reject_message(ch, method_frame.delivery_tag, False)
         return
 
     if writer.write_frame(
@@ -86,8 +98,8 @@ def waveform_callback(ch, method_frame, _header_frame, body):
         units,
         sampling_rate,
         mapped_location_string,
-        matched_mrn[2],
-        matched_mrn[0],
+        csn,
+        mrn,
     ):
         if lookup_success:
             ack_message(ch, method_frame.delivery_tag)
@@ -105,6 +117,7 @@ def receiver():
         host=settings.RABBITMQ_HOST,
         port=settings.RABBITMQ_PORT,
     )
+    logger.info("Connecting to RabbitMQ %s", connection_parameters)
     connection = pika.BlockingConnection(connection_parameters)
     channel = connection.channel()
     channel.basic_qos(prefetch_count=1)
@@ -114,9 +127,17 @@ def receiver():
         auto_ack=False,
         on_message_callback=waveform_callback,
     )
+    logger.info("Connected to RabbitMQ, callback configured")
     try:
         channel.start_consuming()
     except KeyboardInterrupt:
+        logger.warning("Received keyboard interrupt, exiting.")
         channel.stop_consuming()
+    except Exception as e:
+        logger.error("Received other exception")
+        logger.error(e)
+        raise e
 
+
+    logger.info("Closing connection to RabbitMQ")
     connection.close()

--- a/src/controller.py
+++ b/src/controller.py
@@ -64,7 +64,7 @@ class WaveformController:
                 source_variable_id,
                 source_channel_id,
             )
-        except IndexError as e:
+        except KeyError as e:
             reject_message(ch, method_frame.delivery_tag, False)
             logger.error(
                 f"Waveform message {method_frame.delivery_tag} is missing required data {e}."

--- a/src/settings.py
+++ b/src/settings.py
@@ -37,4 +37,6 @@ get_from_env("FTPS_PASSWORD")
 get_from_env("HASHER_API_HOSTNAME")
 get_from_env("HASHER_API_PORT")
 
+get_from_env("LOG_LEVEL", default_value="INFO")
+
 get_from_env("INSTANCE_NAME", required=True)

--- a/src/sql/mrn_based_on_bed_and_datetime.sql
+++ b/src/sql/mrn_based_on_bed_and_datetime.sql
@@ -5,7 +5,8 @@ first entry being the most recent.
 SELECT
   mn.mrn as mrn,
   mn.nhs_number as nhs_number,
-  hv.encounter as csn
+  hv.encounter as csn,
+  mn.research_opt_out as research_opt_out
 FROM {schema_name}.mrn mn
 INNER JOIN {schema_name}.hospital_visit hv
   ON mn.mrn_id = hv.mrn_id

--- a/src/utils.py
+++ b/src/utils.py
@@ -21,4 +21,3 @@ class DedupeFilter(logging.Filter):
         self._last_message = msg
         self._last_time = now
         return True
-

--- a/src/utils.py
+++ b/src/utils.py
@@ -1,0 +1,24 @@
+import logging
+import time
+
+
+class DedupeFilter(logging.Filter):
+    """Suppress repeated identical log messages within a time window."""
+
+    def __init__(self, window_seconds=60, name=""):
+        super().__init__(name)
+        self.window_seconds = window_seconds
+        self._last_message = None
+        self._last_time = 0.0
+        self._dedupe_count = 0
+
+    def filter(self, record):
+        msg = record.getMessage()
+        now = time.monotonic()
+        if msg == self._last_message and (now - self._last_time) < self.window_seconds:
+            self._dedupe_count += 1
+            return False
+        self._last_message = msg
+        self._last_time = now
+        return True
+

--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -8,15 +8,23 @@ from controller import WaveformController
 
 
 @pytest.mark.parametrize(
-    "opt_out, expected_accept",
-    [
-        [True, False],
-        [False, True],
-    ],
+    "opt_out",
+    [True, False],
 )
-def test_controller_callback(monkeypatch, opt_out, expected_accept):
+@pytest.mark.parametrize(
+    "db_connect_failure",
+    [True, False],
+)
+@pytest.mark.parametrize(
+    "bad_data",
+    [True, False],
+)
+def test_controller_callback(monkeypatch, opt_out, db_connect_failure, bad_data):
     emap_db_mock = Mock()
-    emap_db_mock.get_row.return_value = ("mrn", "nhsno", "csn", opt_out)
+    if db_connect_failure:
+        emap_db_mock.get_row.side_effect = ConnectionError("mock database error")
+    else:
+        emap_db_mock.get_row.return_value = ("mrn", "nhsno", "csn", opt_out)
     monkeypatch.setattr("controller.db.starDB", Mock(return_value=emap_db_mock))
 
     write_frame_mock = Mock(return_value=True)
@@ -32,6 +40,9 @@ def test_controller_callback(monkeypatch, opt_out, expected_accept):
         "unit": "uV",
         "numericValues": "[1,2,3]",
     }
+    if bad_data:
+        # simulate a missing key
+        del fake_data["sourceChannelId"]
     fake_data_str = json.dumps(fake_data)
     controller = WaveformController()
 
@@ -43,10 +54,28 @@ def test_controller_callback(monkeypatch, opt_out, expected_accept):
 
     controller.waveform_callback(channel_mock, method_frame_mock, None, fake_data_str)
 
-    emap_db_mock.get_row.assert_called_once()
-    if expected_accept:
-        write_frame_mock.assert_called()
-        channel_mock.basic_ack.assert_called_once_with(delivery_tag)
-    else:
+    if not bad_data:
+        # we at least tried to query the DB
+        emap_db_mock.get_row.assert_called_once()
+
+    if bad_data:
+        write_frame_mock.assert_not_called()
+        # db should not even have been queried if data was bad
+        emap_db_mock.get_row.assert_not_called()
+        channel_mock.basic_reject.assert_called_once_with(delivery_tag, False)
+        channel_mock.basic_ack.assert_not_called()
+    elif db_connect_failure:
+        # if the DB lookup failed, we should not write anything and requeue the message
+        write_frame_mock.assert_not_called()
+        channel_mock.basic_reject.assert_called_once_with(delivery_tag, True)
+        channel_mock.basic_ack.assert_not_called()
+    elif opt_out:
+        # patient has opted out, dump the message
         write_frame_mock.assert_not_called()
         channel_mock.basic_reject.assert_called_once_with(delivery_tag, False)
+        channel_mock.basic_ack.assert_not_called()
+    else:
+        # happy path
+        write_frame_mock.assert_called_once()
+        channel_mock.basic_reject.assert_not_called()
+        channel_mock.basic_ack.assert_called_once_with(delivery_tag)

--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -1,0 +1,52 @@
+import json
+from datetime import datetime
+from unittest.mock import Mock
+
+import pytest
+
+from controller import WaveformController
+
+
+@pytest.mark.parametrize(
+    "opt_out, expected_accept",
+    [
+        [True, False],
+        [False, True],
+    ],
+)
+def test_controller_callback(monkeypatch, opt_out, expected_accept):
+    emap_db_mock = Mock()
+    emap_db_mock.get_row.return_value = ("mrn", "nhsno", "csn", opt_out)
+    monkeypatch.setattr("controller.db.starDB", Mock(return_value=emap_db_mock))
+
+    write_frame_mock = Mock(return_value=True)
+    monkeypatch.setattr("controller.writer.write_frame", write_frame_mock)
+
+    fake_data = {
+        "sourceLocationString": "foo",
+        "mappedLocationString": "loc",
+        "observationTime": datetime.now().timestamp(),
+        "sourceVariableId": "27",
+        "sourceChannelId": "1",
+        "samplingRate": 50,
+        "unit": "uV",
+        "numericValues": "[1,2,3]",
+    }
+    fake_data_str = json.dumps(fake_data)
+    controller = WaveformController()
+
+    method_frame_mock = Mock()
+    delivery_tag = 12345
+    method_frame_mock.delivery_tag = delivery_tag
+    channel_mock = Mock()
+    channel_mock.is_open = True
+
+    controller.waveform_callback(channel_mock, method_frame_mock, None, fake_data_str)
+
+    emap_db_mock.get_row.assert_called_once()
+    if expected_accept:
+        write_frame_mock.assert_called()
+        channel_mock.basic_ack.assert_called_once_with(delivery_tag)
+    else:
+        write_frame_mock.assert_not_called()
+        channel_mock.basic_reject.assert_called_once_with(delivery_tag, False)

--- a/uv.lock
+++ b/uv.lock
@@ -2075,6 +2075,15 @@ wheels = [
 ]
 
 [[package]]
+name = "types-psycopg2"
+version = "2.9.21.20251012"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/9b/b3/2d09eaf35a084cffd329c584970a3fa07101ca465c13cad1576d7c392587/types_psycopg2-2.9.21.20251012.tar.gz", hash = "sha256:4cdafd38927da0cfde49804f39ab85afd9c6e9c492800e42f1f0c1a1b0312935", size = 26710 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ec/0c/05feaf8cb51159f2c0af04b871dab7e98a2f83a3622f5f216331d2dd924c/types_psycopg2-2.9.21.20251012-py3-none-any.whl", hash = "sha256:712bad5c423fe979e357edbf40a07ca40ef775d74043de72bd4544ca328cc57e", size = 24883 },
+]
+
+[[package]]
 name = "typing-extensions"
 version = "4.15.0"
 source = { registry = "https://pypi.org/simple" }
@@ -2133,6 +2142,7 @@ dependencies = [
 dev = [
     { name = "pytest" },
     { name = "stablehash" },
+    { name = "types-psycopg2" },
 ]
 
 [package.metadata]
@@ -2146,6 +2156,7 @@ requires-dist = [
     { name = "requests", specifier = "==2.32.3" },
     { name = "snakemake", specifier = "==9.14.5" },
     { name = "stablehash", marker = "extra == 'dev'", specifier = "==0.3.0" },
+    { name = "types-psycopg2", marker = "extra == 'dev'" },
 ]
 
 [[package]]


### PR DESCRIPTION
Implement opt-out https://github.com/SAFEHR-data/emap/issues/155

We send a "reject without requeue" to rabbitmq for the message and don't write anything out to disk. See also synthetic generator change https://github.com/SAFEHR-data/emap/pull/156 that sets a random 10% of MRNs to be opted out.

Also add unit tests to test opt-out, as well as general error handling in the controller. Fixed one bug discovered this way. Did a small refactor to make controller more testable. So this partially counts towards #23 .

You may want to turn on "hide whitespace" while reviewing this change, as I have refactored some module-level code into a class in `src/controller.py`.
