### PR TITLE
Relax version for pandas and requests to work with newer versions of PIXL

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ name = "waveform_controller"
 version = "0.1.0"
 description = "Add your description here"
 readme = "README.md"
-requires-python = ">=3.11"
+requires-python = ">=3.13"
 dependencies = [
     "pandas>=2.2.3",
     #"pyarrow>=22.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,14 +5,14 @@ description = "Add your description here"
 readme = "README.md"
 requires-python = ">=3.11"
 dependencies = [
-    "pandas==2.2.3",
+    "pandas>=2.2.3",
     #"pyarrow>=22.0",
     "pika>=1.3.2",
     "pre-commit>=4.5.0",
     "snakemake==9.14.5",
     # need to be compatible with PIXL, which currently pins 2.9.10 (arguably it shouldn't)
     "psycopg2-binary>=2.9.10",
-    "requests==2.32.4",
+    "requests>=2.32.4",
     # trick for making a "relative" path, works inside or outside container image
     "core @ file:///${PROJECT_ROOT}/../PIXL/pixl_core",
 ]


### PR DESCRIPTION
PIXL have updated their versions for requests and pandas. I've changed ours to only specify minimum version to avoid doing this again. 